### PR TITLE
1 add zest interface rs232 uart node to the overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Shield name: zest_interface_rs232.
 ## Sample Output 
 This is the output from the JLink UART on the 6tron zest_core_stm32l4a6rg board.
 *** Booting Zephyr OS build v3.7.0 ***
-[00:00:00.000,000] <inf> main: UART device MAX3227IDBR is ready, sending message...
-[00:00:00.002,000] <inf> main: Message sent!
+main: UART device MAX3227IDBR is ready, sending message...
+main: Message sent!

--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 Zest_Interface_RS232 board support for Zephyr OS.
 
 ## Usage
-This board enables the following sensors:
-- List Zest_Interface_RS232 sensors here
+The zest-interface-rs232-uart alias is exposed by the overlay, allowing to use the RS232 interface with the default 6TRON uart interface (sixtron_uart).
 
-:bulb: Sensors' drivers should also be added to your workspace:
-- List Zephyr OS drivers here
+Shield name: zest_interface_rs232.
+
+## Sample Output 
+This is the output from the JLink UART on the 6tron zest_core_stm32l4a6rg board.
+*** Booting Zephyr OS build v3.7.0 ***
+[00:00:00.000,000] <inf> main: UART device MAX3227IDBR is ready, sending message...
+[00:00:00.002,000] <inf> main: Message sent!

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Shield name: zest_interface_rs232.
 
 ## Sample Output 
 This is the output from the JLink UART on the 6tron zest_core_stm32l4a6rg board.
+
 *** Booting Zephyr OS build v3.7.0 ***
 
  ```shell

--- a/README.md
+++ b/README.md
@@ -3,18 +3,6 @@
 Zest_Interface_RS232 board support for Zephyr OS.
 
 ## Usage
-The zest-interface-rs232-uart alias is exposed by the overlay, allowing to use the RS232 interface with the default 6TRON uart interface (sixtron_uart).
+The `zest-interface-rs232-uart` alias is exposed by the overlay, allowing to use the RS485 interface with the default 6TRON uart interface (`sixtron_uart`).
 
-Shield name: zest_interface_rs232.
-
-## Sample Output 
-This is the output from the JLink UART on the 6tron zest_core_stm32l4a6rg board.
-
-*** Booting Zephyr OS build v3.7.0 ***
-
- ```shell
-  main: UART device MAX3227IDBR is ready, sending message...
-  ```
- ```shell
-  main: Message sent!
-  ```
+Shield name: `zest_interface_rs232`

--- a/README.md
+++ b/README.md
@@ -10,5 +10,10 @@ Shield name: zest_interface_rs232.
 ## Sample Output 
 This is the output from the JLink UART on the 6tron zest_core_stm32l4a6rg board.
 *** Booting Zephyr OS build v3.7.0 ***
-main: UART device MAX3227IDBR is ready, sending message...
-main: Message sent!
+
+ ```shell
+  main: UART device MAX3227IDBR is ready, sending message...
+  ```
+ ```shell
+  main: Message sent!
+  ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Zest_Interface_RS232 board support for Zephyr OS.
 
 ## Usage
-The `zest-interface-rs232-uart` alias is exposed by the overlay, allowing to use the RS485 interface with the default 6TRON uart interface (`sixtron_uart`).
+The `zest_interface_rs232_uart` label is exposed by the overlay, allowing to use the RS232 interface with the default 6TRON uart interface (`sixtron_uart`).
 
 Shield name: `zest_interface_rs232`

--- a/boards/shields/zest_interface_rs232/zest_interface_rs232.overlay
+++ b/boards/shields/zest_interface_rs232/zest_interface_rs232.overlay
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- */
+*/
 
- / {
+/ {
     aliases {
         zest-interface-rs232-uart = &sixtron_uart;
     };

--- a/boards/shields/zest_interface_rs232/zest_interface_rs232.overlay
+++ b/boards/shields/zest_interface_rs232/zest_interface_rs232.overlay
@@ -2,3 +2,11 @@
  * Copyright (c) 2024, CATIE
  * SPDX-License-Identifier: Apache-2.0
  */
+
+ */
+
+ / {
+    aliases {
+        zest-interface-rs232-uart = &sixtron_uart;
+    };
+};

--- a/boards/shields/zest_interface_rs232/zest_interface_rs232.overlay
+++ b/boards/shields/zest_interface_rs232/zest_interface_rs232.overlay
@@ -3,10 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-*/
-
-/ {
-    aliases {
-        zest-interface-rs232-uart = &sixtron_uart;
-    };
-};
+zest_interface_rs232_uart: &sixtron_uart {};


### PR DESCRIPTION
This issue perform the following tasks:

- Added the zest-interface-rs232-uart alias to the device tree overlay(default sixtron_uart interface)
- Update Readme
